### PR TITLE
fix: baseVestedAmount() & reentrancy attack

### DIFF
--- a/docs/VTVLVesting.md
+++ b/docs/VTVLVesting.md
@@ -280,7 +280,7 @@ Withdraw the full claimable balance.
 ### withdrawAdmin
 
 ```solidity
-function withdrawAdmin(uint112 _amountRequested) external nonpayable
+function withdrawAdmin(uint256 _amountRequested) external nonpayable
 ```
 
 Admin withdrawal of the unallocated tokens.
@@ -291,7 +291,7 @@ Admin withdrawal of the unallocated tokens.
 
 | Name | Type | Description |
 |---|---|---|
-| _amountRequested | uint112 | - the amount that we want to withdraw |
+| _amountRequested | uint256 | - the amount that we want to withdraw |
 
 ### withdrawOtherToken
 

--- a/docs/elin/contracts/security/ReentrancyGuard.md
+++ b/docs/elin/contracts/security/ReentrancyGuard.md
@@ -1,0 +1,12 @@
+# ReentrancyGuard
+
+
+
+
+
+
+
+*Contract module that helps prevent reentrant calls to a function. Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier available, which can be applied to functions to make sure there are no nested (reentrant) calls to them. Note that because there is a single `nonReentrant` guard, functions marked as `nonReentrant` may not call one another. This can be worked around by making those functions `private`, and then adding `external` `nonReentrant` entry points to them. TIP: If you would like to learn more about reentrancy and alternative ways to protect against it, check out our blog post https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].*
+
+
+


### PR DESCRIPTION
Closes: #6 

Updates:
1. Update _baseVestedAmount()
- Fix incorrect data size
- Fix returning correct historical value
2. Add Reentrancy disabler
- Migrated Openzeppelin Reentrancy module to disable reentrancy attack
3. Update docs